### PR TITLE
Keyframe events for 0.x

### DIFF
--- a/plugins/janus_videoroom.c
+++ b/plugins/janus_videoroom.c
@@ -5771,11 +5771,47 @@ void janus_videoroom_incoming_rtp(janus_plugin_session *handle, janus_plugin_rtp
 					return;
 				}
 				if(participant->vcodec == JANUS_VIDEOCODEC_VP8) {
-					if(janus_vp8_is_keyframe(payload, plen))
-						participant->fir_latest = now;
+					if(janus_vp8_is_keyframe(payload, plen)) {
+						ps->fir_latest = now;
+
+						janus_mutex_lock(&videoroom->mutex);
+						json_t *event = json_object();
+						json_object_set_new(event, "videoroom", json_string("keyframe"));
+						json_object_set_new(event, "room", string_ids ? json_string(videoroom->room_id_str) : json_integer(videoroom->room_id));
+						json_object_set_new(event, "id", string_ids ? json_string(participant->user_id_str) : json_integer(participant->user_id));
+						json_object_set_new(event, "mindex", json_integer(ps->mindex));
+						json_object_set_new(event, "mid", json_string(ps->mid));
+						json_object_set_new(event, "resolution", janus_vp8_get_keyframe_resolution(payload, plen));
+
+						janus_videoroom_notify_participants(participant, event, TRUE);
+						if(notify_events && gateway->events_is_enabled()) {
+							gateway->notify_event(&janus_videoroom_plugin, session->handle, event);
+						}
+
+						json_decref(event);
+						janus_mutex_unlock(&videoroom->mutex);
+					}
 				} else if(participant->vcodec == JANUS_VIDEOCODEC_VP9) {
-					if(janus_vp9_is_keyframe(payload, plen))
-						participant->fir_latest = now;
+					if(janus_vp9_is_keyframe(payload, plen)) {
+						ps->fir_latest = now;
+
+						janus_mutex_lock(&videoroom->mutex);
+						json_t *event = json_object();
+						json_object_set_new(event, "videoroom", json_string("keyframe"));
+						json_object_set_new(event, "room", string_ids ? json_string(videoroom->room_id_str) : json_integer(videoroom->room_id));
+						json_object_set_new(event, "id", string_ids ? json_string(participant->user_id_str) : json_integer(participant->user_id));
+						json_object_set_new(event, "mindex", json_integer(ps->mindex));
+						json_object_set_new(event, "mid", json_string(ps->mid));
+						json_object_set_new(event, "resolution", janus_vp9_get_keyframe_resolution(payload, plen));
+
+						janus_videoroom_notify_participants(participant, event, TRUE);
+						if(notify_events && gateway->events_is_enabled()) {
+							gateway->notify_event(&janus_videoroom_plugin, session->handle, event);
+						}
+
+						json_decref(event);
+						janus_mutex_unlock(&videoroom->mutex);
+					}
 				} else if(participant->vcodec == JANUS_VIDEOCODEC_H264) {
 					if(janus_h264_is_keyframe(payload, plen))
 						participant->fir_latest = now;

--- a/utils.h
+++ b/utils.h
@@ -318,11 +318,23 @@ gboolean janus_json_is_valid(json_t *val, json_type jtype, unsigned int flags);
  * @returns TRUE if it's a keyframe, FALSE otherwise */
 gboolean janus_vp8_is_keyframe(const char *buffer, int len);
 
+/*! \brief Helper method to get resolution info from a VP8 keyframe
+ * @param[in] buffer The RTP payload to process
+ * @param[in] len The length of the RTP payload
+ * @returns json_t instance containing width and height if the input was a valid keyframe */
+json_t *janus_vp8_get_keyframe_resolution(const char *buffer, int len);
+
 /*! \brief Helper method to check if a VP9 frame is a keyframe or not
  * @param[in] buffer The RTP payload to process
  * @param[in] len The length of the RTP payload
  * @returns TRUE if it's a keyframe, FALSE otherwise */
 gboolean janus_vp9_is_keyframe(const char *buffer, int len);
+
+/*! \brief Helper method to get resolution info from a VP9 keyframe
+ * @param[in] buffer The RTP payload to process
+ * @param[in] len The length of the RTP payload
+ * @returns json_t instance containing width and height if the input was a valid keyframe */
+json_t *janus_vp9_get_keyframe_resolution(const char *buffer, int len);
 
 /*! \brief Helper method to check if an H.264 frame is a keyframe or not
  * @param[in] buffer The RTP payload to process


### PR DESCRIPTION
## Summary

Added `keyframe` events to janus videoroom plugin. These events can be used to monitor video resolution changes in the stream.

> NOTE: only supports VP8 and VP9 codecs for now... Streams with other codecs will **not** emit these events.

### Example
```
{
  videoroom: 'keyframe',
  room: 4473808368667781,
  id: 4302698742002272,
  mindex: 1,
  mid: '1',
  resolution: { width: 640, height: 360 }
}
```